### PR TITLE
docs: Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Twilio Support
+    url: https://twilio.com/help/contact
+    about: Get Support
+  - name: Documentation
+    url: https://www.twilio.com/docs/platform/tac
+    about: View TAC Documentation

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest an idea for aws-twilio-agent-connect-python
+description: Suggest an idea for twilio-agent-connect-aws
 title: "[Feature Request]: "
 labels: "type: community enhancement"
 body:
@@ -8,13 +8,13 @@ body:
       label: Preflight Checklist
       description: Please ensure you've completed all of the following.
       options:
-        - label: I have read the [Contributing Guidelines](https://github.com/twilio/aws-twilio-agent-connect-python/blob/main/CONTRIBUTING.md) for this project.
+        - label: I have read the [Contributing Guidelines](https://github.com/twilio/twilio-agent-connect-aws/blob/main/CONTRIBUTING.md) for this project.
           required: true
-        - label: I agree to follow the [Code of Conduct](https://github.com/twilio/aws-twilio-agent-connect-python/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
+        - label: I agree to follow the [Code of Conduct](https://github.com/twilio/twilio-agent-connect-aws/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
           required: true
-        - label: I have searched the [issue tracker](https://github.com/twilio/aws-twilio-agent-connect-python/issues) for a feature request that matches the one I want to file, without success.
+        - label: I have searched the [issue tracker](https://github.com/twilio/twilio-agent-connect-aws/issues) for a feature request that matches the one I want to file, without success.
           required: true
-        - label: This is not a general Twilio feature request or bug report. It is a feature request for the aws-twilio-agent-connect-python package.
+        - label: This is not a general Twilio feature request or bug report. It is a feature request for the twilio-agent-connect-aws package.
           required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest an idea for aws-twilio-agent-connect-python
+title: "[Feature Request]: "
+labels: "type: community enhancement"
+body:
+  - type: checkboxes
+    attributes:
+      label: Preflight Checklist
+      description: Please ensure you've completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/twilio/aws-twilio-agent-connect-python/blob/main/CONTRIBUTING.md) for this project.
+          required: true
+        - label: I agree to follow the [Code of Conduct](https://github.com/twilio/aws-twilio-agent-connect-python/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
+          required: true
+        - label: I have searched the [issue tracker](https://github.com/twilio/aws-twilio-agent-connect-python/issues) for a feature request that matches the one I want to file, without success.
+          required: true
+        - label: This is not a general Twilio feature request or bug report. It is a feature request for the aws-twilio-agent-connect-python package.
+          required: true
+  - type: textarea
+    attributes:
+      label: Problem Description
+      description: Please add a clear and concise description of the problem you are seeking to solve with this feature request.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you would like in a clear and concise manner.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Alternatives Considered
+      description: A clear and concise description of any alternative solutions or features you have considered.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: Add any other context about the problem here.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/config.yml` with links to Twilio Support and TAC documentation
- Add `.github/ISSUE_TEMPLATE/feature-request.yml` with preflight checklist, problem description, proposed solution, alternatives, and additional info sections

## Test plan
- [ ] Verify templates render at `/issues/new/choose` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)