### PR TITLE
chore: Release v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   </h2>
 
   <div align="center">
+    <a href="https://pypi.org/project/twilio-agent-connect-aws/"><img alt="PyPI" src="https://img.shields.io/pypi/v/twilio-agent-connect-aws.svg"/></a>
     <a href="https://github.com/twilio/twilio-agent-connect-aws"><img alt="Python SDK" src="https://img.shields.io/badge/Python-3.10+-3776AB.svg"/></a>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-green.svg"/></a>
     <a href="getting_started/examples/"><img alt="Getting Started" src="https://img.shields.io/badge/Getting%20Started-Examples-F22F46.svg"/></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twilio-agent-connect-aws"
-version = "1.0.0"
+version = "1.0.1"
 description = "AWS integrations for Twilio Agent Connect (TAC) - adapters and servers for AWS agent runtimes"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump version to 1.0.1 for PyPI release.

This release includes all changes from PR #15:
- TACAWSFastAPIServer with ALB middleware
- AgentCore streaming fix (chunk_size 10→1024)
- Deploy folder improvements

Ready to publish to PyPI.