### PR TITLE
ci: Add deploy workflow for PyPI publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           version: "0.9.26"
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Validate tag format and version match
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,4 +69,4 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@4cf0fdb7e1623e99dab752bc00bab23c0b69d050 # v1.14.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    name: Test - Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5
+        with:
+          version: "0.9.26"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --all-extras --all-packages
+      - run: uv run ruff check src/tac_aws getting_started
+      - run: uv run ruff format --check src/tac_aws getting_started
+      - run: MYPYPATH=src uv run mypy src/tac_aws getting_started
+      - run: uv run pytest
+
+  deploy:
+    name: Publish to PyPI
+    needs: [test]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5
+        with:
+          version: "0.9.26"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Validate tag format and version match
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Release tag must be in the form v1.2.3 (got '$TAG')"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          PKG_VERSION=$(python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG does not match pyproject.toml version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
## Summary

Add `.github/workflows/deploy.yml` that triggers on GitHub Release (published) to publish the package to PyPI with OIDC trusted publishing and Sigstore attestations. Tests run across Python 3.10–3.13 matrix before the deploy job proceeds.

**Setup required:**
- GitHub environment `pypi` with reviewer approval (needs to be configured)
- PyPI trusted publisher linked to this repo/workflow/environment on pypi.org

## How to cut a release

1. Bump the version in `pyproject.toml` (and open a PR for it)
2. After merging, go to [Releases](https://github.com/twilio/twilio-agent-connect-aws/releases/new)
3. Create a new tag matching the version: `v1.2.3`
4. Click "Generate release notes" for a changelog
5. Publish the release
6. The workflow runs tests (Python 3.10–3.13), then waits for `pypi` environment approval
7. After approval, the package is published to PyPI with attestations

## Type of Change

- [x] New feature

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)