### PR TITLE
Migrate AgentCore Lambda to AWS Secrets Manager for Twilio credentials

### DIFF
--- a/deploy/agentcore_aws_lambda/Makefile
+++ b/deploy/agentcore_aws_lambda/Makefile
@@ -88,14 +88,7 @@ endif
 		TWILIO_API_SECRET="$(TWILIO_API_SECRET)" \
 		TWILIO_PHONE_NUMBER="$(TWILIO_PHONE_NUMBER)" \
 		TWILIO_CONVERSATION_CONFIGURATION_ID="$(TWILIO_CONVERSATION_CONFIGURATION_ID)" \
-		python3 -c 'import json, os; print(json.dumps({ \
-			"TWILIO_ACCOUNT_SID": os.environ["TWILIO_ACCOUNT_SID"], \
-			"TWILIO_AUTH_TOKEN": os.environ["TWILIO_AUTH_TOKEN"], \
-			"TWILIO_API_KEY": os.environ["TWILIO_API_KEY"], \
-			"TWILIO_API_SECRET": os.environ["TWILIO_API_SECRET"], \
-			"TWILIO_PHONE_NUMBER": os.environ["TWILIO_PHONE_NUMBER"], \
-			"TWILIO_CONVERSATION_CONFIGURATION_ID": os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"] \
-		}))' | \
+		python3 -c 'import json, os; print(json.dumps({"TWILIO_ACCOUNT_SID": os.environ["TWILIO_ACCOUNT_SID"], "TWILIO_AUTH_TOKEN": os.environ["TWILIO_AUTH_TOKEN"], "TWILIO_API_KEY": os.environ["TWILIO_API_KEY"], "TWILIO_API_SECRET": os.environ["TWILIO_API_SECRET"], "TWILIO_PHONE_NUMBER": os.environ["TWILIO_PHONE_NUMBER"], "TWILIO_CONVERSATION_CONFIGURATION_ID": os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"]}))' | \
 		aws secretsmanager put-secret-value \
 			--secret-id tac/twilio-credentials \
 			--region $(AWS_REGION) \

--- a/deploy/agentcore_aws_lambda/Makefile
+++ b/deploy/agentcore_aws_lambda/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build deploy deploy-all deploy-agentcore deploy-lambda bootstrap clean secret-update help
+.PHONY: build deploy deploy-all deploy-agentcore deploy-lambda bootstrap clean secret-update destroy help
 
 # Load environment variables from .env file
 -include .env
@@ -18,12 +18,14 @@ help:
 	@echo "  deploy-all       - Build and deploy all stacks (Secrets, AgentCore, Lambda)"
 	@echo "  deploy-agentcore - Build and deploy only AgentCore stack"
 	@echo "  deploy-lambda    - Build and deploy only Lambda stack"
-	@echo "  secret-update    - Update Secrets Manager with values from .env"
+	@echo "  secret-update    - Update Secrets Manager with credentials from .env"
+	@echo "  destroy          - Destroy all stacks (Lambda, AgentCore, Secrets)"
 	@echo "  clean            - Clean build artifacts"
 	@echo ""
 	@echo "Usage:"
 	@echo "  make bootstrap   # One-time setup"
 	@echo "  make deploy      # Build, deploy, and update secrets"
+	@echo "  make destroy     # Delete all AWS resources"
 
 # Bootstrap CDK (one-time setup)
 bootstrap:
@@ -55,7 +57,7 @@ build:
 	@echo "Building CDK..."
 	cd cdk && npm ci && npm run build
 
-# Update Secrets Manager with values from .env
+# Update Secrets Manager with credentials from .env (secrets only, not configuration)
 secret-update:
 ifndef AWS_PROFILE
 	$(error AWS_PROFILE is not set in .env file. Add AWS_PROFILE=<your-profile> to deploy/agentcore_aws_lambda/.env)
@@ -72,23 +74,15 @@ endif
 ifndef TWILIO_API_SECRET
 	$(error TWILIO_API_SECRET is not set in .env file)
 endif
-ifndef TWILIO_PHONE_NUMBER
-	$(error TWILIO_PHONE_NUMBER is not set in .env file)
-endif
-ifndef TWILIO_CONVERSATION_CONFIGURATION_ID
-	$(error TWILIO_CONVERSATION_CONFIGURATION_ID is not set in .env file)
-endif
 ifndef AWS_REGION
 	$(error AWS_REGION is not set in .env file)
 endif
-	@echo "Updating Secrets Manager with Twilio credentials and configuration from .env..."
+	@echo "Updating Secrets Manager with Twilio credentials from .env..."
 	@TWILIO_ACCOUNT_SID="$(TWILIO_ACCOUNT_SID)" \
 		TWILIO_AUTH_TOKEN="$(TWILIO_AUTH_TOKEN)" \
 		TWILIO_API_KEY="$(TWILIO_API_KEY)" \
 		TWILIO_API_SECRET="$(TWILIO_API_SECRET)" \
-		TWILIO_PHONE_NUMBER="$(TWILIO_PHONE_NUMBER)" \
-		TWILIO_CONVERSATION_CONFIGURATION_ID="$(TWILIO_CONVERSATION_CONFIGURATION_ID)" \
-		python3 -c 'import json, os; print(json.dumps({"TWILIO_ACCOUNT_SID": os.environ["TWILIO_ACCOUNT_SID"], "TWILIO_AUTH_TOKEN": os.environ["TWILIO_AUTH_TOKEN"], "TWILIO_API_KEY": os.environ["TWILIO_API_KEY"], "TWILIO_API_SECRET": os.environ["TWILIO_API_SECRET"], "TWILIO_PHONE_NUMBER": os.environ["TWILIO_PHONE_NUMBER"], "TWILIO_CONVERSATION_CONFIGURATION_ID": os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"]}))' | \
+		python3 -c 'import json, os; print(json.dumps({"TWILIO_ACCOUNT_SID": os.environ["TWILIO_ACCOUNT_SID"], "TWILIO_AUTH_TOKEN": os.environ["TWILIO_AUTH_TOKEN"], "TWILIO_API_KEY": os.environ["TWILIO_API_KEY"], "TWILIO_API_SECRET": os.environ["TWILIO_API_SECRET"]}))' | \
 		aws secretsmanager put-secret-value \
 			--secret-id tac/twilio-credentials \
 			--region $(AWS_REGION) \
@@ -107,7 +101,7 @@ endif
 	cd cdk && AWS_PROFILE=$(AWS_PROFILE) npx aws-cdk deploy TacSecretsStack --require-approval never
 	@echo ""
 	@echo "═══════════════════════════════════════════════════════════"
-	@echo "Step 2/3: Updating secret with real credentials from .env..."
+	@echo "Step 2/3: Updating Secrets Manager with credentials from .env..."
 	@echo "═══════════════════════════════════════════════════════════"
 	@$(MAKE) secret-update
 	@echo ""
@@ -116,12 +110,7 @@ endif
 	@echo "═══════════════════════════════════════════════════════════"
 	cd cdk && AWS_PROFILE=$(AWS_PROFILE) npx aws-cdk deploy TacAgentCoreStack TacLambdaStack --require-approval never
 	@echo ""
-	@echo "✓ All stacks deployed with real credentials!"
-	@echo ""
-	@echo "View stack outputs:"
-	@echo "  aws cloudformation describe-stacks --stack-name TacSecretsStack --profile $(AWS_PROFILE)"
-	@echo "  aws cloudformation describe-stacks --stack-name TacAgentCoreStack --profile $(AWS_PROFILE)"
-	@echo "  aws cloudformation describe-stacks --stack-name TacLambdaStack --profile $(AWS_PROFILE)"
+	@echo "✓ All stacks deployed!"
 
 # Deploy only AgentCore stack
 deploy-agentcore: build
@@ -147,9 +136,24 @@ endif
 # Note: deploy-all now handles secret-update in the correct order automatically
 deploy: deploy-all
 
+# Destroy all stacks (reverse order: Lambda → AgentCore → Secrets)
+destroy:
+ifndef AWS_PROFILE
+	$(error AWS_PROFILE is not set in .env file. Add AWS_PROFILE=<your-profile> to deploy/agentcore_aws_lambda/.env)
+endif
+	@echo "⚠️  WARNING: This will destroy all stacks and delete all resources!"
+	@echo ""
+	@echo "Destroying stacks in order: Lambda → AgentCore → Secrets"
+	@echo ""
+	cd cdk && AWS_PROFILE=$(AWS_PROFILE) npx aws-cdk destroy TacLambdaStack TacAgentCoreStack TacSecretsStack --force
+	@echo ""
+	@echo "✓ All stacks destroyed!"
+
 # Clean build artifacts
 clean:
 	rm -rf agent/.venv
+	rm -rf agent/__pycache__
+	rm -rf lambda/__pycache__
 	rm -rf cdk/node_modules
 	rm -rf cdk/cdk.out
 	rm -rf cdk/dist

--- a/deploy/agentcore_aws_lambda/Makefile
+++ b/deploy/agentcore_aws_lambda/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build deploy deploy-all deploy-agentcore deploy-lambda bootstrap clean help
+.PHONY: build deploy deploy-all deploy-agentcore deploy-lambda bootstrap clean secret-update help
 
 # Load environment variables from .env file
 -include .env
@@ -14,15 +14,16 @@ help:
 	@echo "Available targets:"
 	@echo "  bootstrap        - Bootstrap CDK (one-time setup)"
 	@echo "  build            - Build agent code and CDK"
-	@echo "  deploy           - Build and deploy both stacks (recommended)"
-	@echo "  deploy-all       - Build and deploy both AgentCore and Lambda stacks"
+	@echo "  deploy           - Build, deploy all stacks, and update secrets (recommended)"
+	@echo "  deploy-all       - Build and deploy all stacks (Secrets, AgentCore, Lambda)"
 	@echo "  deploy-agentcore - Build and deploy only AgentCore stack"
 	@echo "  deploy-lambda    - Build and deploy only Lambda stack"
+	@echo "  secret-update    - Update Secrets Manager with values from .env"
 	@echo "  clean            - Clean build artifacts"
 	@echo ""
 	@echo "Usage:"
 	@echo "  make bootstrap   # One-time setup"
-	@echo "  make deploy      # Build and deploy both stacks"
+	@echo "  make deploy      # Build, deploy, and update secrets"
 
 # Bootstrap CDK (one-time setup)
 bootstrap:
@@ -54,17 +55,60 @@ build:
 	@echo "Building CDK..."
 	cd cdk && npm ci && npm run build
 
-# Deploy all stacks (AgentCore + Lambda)
+# Update Secrets Manager with values from .env
+secret-update:
+ifndef AWS_PROFILE
+	$(error AWS_PROFILE is not set in .env file. Add AWS_PROFILE=<your-profile> to deploy/agentcore_aws_lambda/.env)
+endif
+ifndef TWILIO_ACCOUNT_SID
+	$(error TWILIO_ACCOUNT_SID is not set in .env file)
+endif
+ifndef TWILIO_AUTH_TOKEN
+	$(error TWILIO_AUTH_TOKEN is not set in .env file)
+endif
+ifndef TWILIO_API_KEY
+	$(error TWILIO_API_KEY is not set in .env file)
+endif
+ifndef TWILIO_API_SECRET
+	$(error TWILIO_API_SECRET is not set in .env file)
+endif
+ifndef TWILIO_PHONE_NUMBER
+	$(error TWILIO_PHONE_NUMBER is not set in .env file)
+endif
+ifndef TWILIO_CONVERSATION_CONFIGURATION_ID
+	$(error TWILIO_CONVERSATION_CONFIGURATION_ID is not set in .env file)
+endif
+	@echo "Updating Secrets Manager with Twilio credentials and configuration from .env..."
+	@aws secretsmanager put-secret-value \
+		--secret-id tac/twilio-credentials \
+		--secret-string '{"TWILIO_ACCOUNT_SID":"$(TWILIO_ACCOUNT_SID)","TWILIO_AUTH_TOKEN":"$(TWILIO_AUTH_TOKEN)","TWILIO_API_KEY":"$(TWILIO_API_KEY)","TWILIO_API_SECRET":"$(TWILIO_API_SECRET)","TWILIO_PHONE_NUMBER":"$(TWILIO_PHONE_NUMBER)","TWILIO_CONVERSATION_CONFIGURATION_ID":"$(TWILIO_CONVERSATION_CONFIGURATION_ID)"}' \
+		--profile $(AWS_PROFILE) > /dev/null
+	@echo "✓ Secrets updated successfully!"
+
+# Deploy all stacks in stages (Secrets → Update → AgentCore + Lambda)
 deploy-all: build
 ifndef AWS_PROFILE
 	$(error AWS_PROFILE is not set in .env file. Add AWS_PROFILE=<your-profile> to deploy/agentcore_aws_lambda/.env)
 endif
-	@echo "Deploying all stacks (AgentCore + Lambda)..."
-	cd cdk && AWS_PROFILE=$(AWS_PROFILE) npx aws-cdk deploy --all --require-approval never
+	@echo "═══════════════════════════════════════════════════════════"
+	@echo "Step 1/3: Deploying Secrets stack..."
+	@echo "═══════════════════════════════════════════════════════════"
+	cd cdk && AWS_PROFILE=$(AWS_PROFILE) npx aws-cdk deploy TacSecretsStack --require-approval never
 	@echo ""
-	@echo "✓ All stacks deployed!"
+	@echo "═══════════════════════════════════════════════════════════"
+	@echo "Step 2/3: Updating secret with real credentials from .env..."
+	@echo "═══════════════════════════════════════════════════════════"
+	@$(MAKE) secret-update
+	@echo ""
+	@echo "═══════════════════════════════════════════════════════════"
+	@echo "Step 3/3: Deploying AgentCore and Lambda stacks..."
+	@echo "═══════════════════════════════════════════════════════════"
+	cd cdk && AWS_PROFILE=$(AWS_PROFILE) npx aws-cdk deploy TacAgentCoreStack TacLambdaStack --require-approval never
+	@echo ""
+	@echo "✓ All stacks deployed with real credentials!"
 	@echo ""
 	@echo "View stack outputs:"
+	@echo "  aws cloudformation describe-stacks --stack-name TacSecretsStack --profile $(AWS_PROFILE)"
 	@echo "  aws cloudformation describe-stacks --stack-name TacAgentCoreStack --profile $(AWS_PROFILE)"
 	@echo "  aws cloudformation describe-stacks --stack-name TacLambdaStack --profile $(AWS_PROFILE)"
 
@@ -88,7 +132,8 @@ endif
 	@echo ""
 	@echo "✓ Lambda stack deployed!"
 
-# Alias for deploy-all
+# Deploy and update secrets (recommended workflow)
+# Note: deploy-all now handles secret-update in the correct order automatically
 deploy: deploy-all
 
 # Clean build artifacts

--- a/deploy/agentcore_aws_lambda/Makefile
+++ b/deploy/agentcore_aws_lambda/Makefile
@@ -78,11 +78,23 @@ endif
 ifndef TWILIO_CONVERSATION_CONFIGURATION_ID
 	$(error TWILIO_CONVERSATION_CONFIGURATION_ID is not set in .env file)
 endif
+ifndef AWS_REGION
+	$(error AWS_REGION is not set in .env file)
+endif
 	@echo "Updating Secrets Manager with Twilio credentials and configuration from .env..."
-	@aws secretsmanager put-secret-value \
-		--secret-id tac/twilio-credentials \
-		--secret-string '{"TWILIO_ACCOUNT_SID":"$(TWILIO_ACCOUNT_SID)","TWILIO_AUTH_TOKEN":"$(TWILIO_AUTH_TOKEN)","TWILIO_API_KEY":"$(TWILIO_API_KEY)","TWILIO_API_SECRET":"$(TWILIO_API_SECRET)","TWILIO_PHONE_NUMBER":"$(TWILIO_PHONE_NUMBER)","TWILIO_CONVERSATION_CONFIGURATION_ID":"$(TWILIO_CONVERSATION_CONFIGURATION_ID)"}' \
-		--profile $(AWS_PROFILE) > /dev/null
+	@python3 -c 'import json, sys; print(json.dumps({ \
+		"TWILIO_ACCOUNT_SID": sys.argv[1], \
+		"TWILIO_AUTH_TOKEN": sys.argv[2], \
+		"TWILIO_API_KEY": sys.argv[3], \
+		"TWILIO_API_SECRET": sys.argv[4], \
+		"TWILIO_PHONE_NUMBER": sys.argv[5], \
+		"TWILIO_CONVERSATION_CONFIGURATION_ID": sys.argv[6] \
+	}))' "$(TWILIO_ACCOUNT_SID)" "$(TWILIO_AUTH_TOKEN)" "$(TWILIO_API_KEY)" "$(TWILIO_API_SECRET)" "$(TWILIO_PHONE_NUMBER)" "$(TWILIO_CONVERSATION_CONFIGURATION_ID)" | \
+		aws secretsmanager put-secret-value \
+			--secret-id tac/twilio-credentials \
+			--region $(AWS_REGION) \
+			--profile $(AWS_PROFILE) \
+			--secret-string file:///dev/stdin > /dev/null
 	@echo "✓ Secrets updated successfully!"
 
 # Deploy all stacks in stages (Secrets → Update → AgentCore + Lambda)

--- a/deploy/agentcore_aws_lambda/Makefile
+++ b/deploy/agentcore_aws_lambda/Makefile
@@ -82,14 +82,20 @@ ifndef AWS_REGION
 	$(error AWS_REGION is not set in .env file)
 endif
 	@echo "Updating Secrets Manager with Twilio credentials and configuration from .env..."
-	@python3 -c 'import json, sys; print(json.dumps({ \
-		"TWILIO_ACCOUNT_SID": sys.argv[1], \
-		"TWILIO_AUTH_TOKEN": sys.argv[2], \
-		"TWILIO_API_KEY": sys.argv[3], \
-		"TWILIO_API_SECRET": sys.argv[4], \
-		"TWILIO_PHONE_NUMBER": sys.argv[5], \
-		"TWILIO_CONVERSATION_CONFIGURATION_ID": sys.argv[6] \
-	}))' "$(TWILIO_ACCOUNT_SID)" "$(TWILIO_AUTH_TOKEN)" "$(TWILIO_API_KEY)" "$(TWILIO_API_SECRET)" "$(TWILIO_PHONE_NUMBER)" "$(TWILIO_CONVERSATION_CONFIGURATION_ID)" | \
+	@TWILIO_ACCOUNT_SID="$(TWILIO_ACCOUNT_SID)" \
+		TWILIO_AUTH_TOKEN="$(TWILIO_AUTH_TOKEN)" \
+		TWILIO_API_KEY="$(TWILIO_API_KEY)" \
+		TWILIO_API_SECRET="$(TWILIO_API_SECRET)" \
+		TWILIO_PHONE_NUMBER="$(TWILIO_PHONE_NUMBER)" \
+		TWILIO_CONVERSATION_CONFIGURATION_ID="$(TWILIO_CONVERSATION_CONFIGURATION_ID)" \
+		python3 -c 'import json, os; print(json.dumps({ \
+			"TWILIO_ACCOUNT_SID": os.environ["TWILIO_ACCOUNT_SID"], \
+			"TWILIO_AUTH_TOKEN": os.environ["TWILIO_AUTH_TOKEN"], \
+			"TWILIO_API_KEY": os.environ["TWILIO_API_KEY"], \
+			"TWILIO_API_SECRET": os.environ["TWILIO_API_SECRET"], \
+			"TWILIO_PHONE_NUMBER": os.environ["TWILIO_PHONE_NUMBER"], \
+			"TWILIO_CONVERSATION_CONFIGURATION_ID": os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"] \
+		}))' | \
 		aws secretsmanager put-secret-value \
 			--secret-id tac/twilio-credentials \
 			--region $(AWS_REGION) \

--- a/deploy/agentcore_aws_lambda/README.md
+++ b/deploy/agentcore_aws_lambda/README.md
@@ -162,19 +162,26 @@ AWS_PROFILE=your-profile-name          # Profile name from step 2
 AWS_ACCOUNT_ID=123456789012            # Account ID from step 3
 AWS_REGION=us-east-1
 
-# Twilio Configuration
+# Twilio Credentials (stored in AWS Secrets Manager)
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your_auth_token
 TWILIO_API_KEY=SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_API_SECRET=your_api_secret
+
+# Twilio Configuration (passed as environment variables)
 TWILIO_PHONE_NUMBER=+1234567890
 TWILIO_CONVERSATION_CONFIGURATION_ID=WRxxxx
 ```
 
-**Where to find Twilio credentials:**
+**Where to find Twilio values:**
 - Account SID & Auth Token: Twilio Console → Account → API Keys & Tokens
 - API Key & Secret: Create new API Key
+- Phone Number: Twilio Console → Phone Numbers
 - Conversation Configuration ID: Twilio Console → Conversation Orchestrator
+
+**Security Model:**
+- Credentials (Account SID, Auth Token, API Key, API Secret) are stored in AWS Secrets Manager
+- Configuration (Phone Number, Conversation Configuration ID) are passed as environment variables during deployment
 
 ### 2. Bootstrap CDK (One-Time Setup)
 

--- a/deploy/agentcore_aws_lambda/agent/main.py
+++ b/deploy/agentcore_aws_lambda/agent/main.py
@@ -9,18 +9,19 @@ from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from strands import Agent
 from strands.models import BedrockModel
 from strands.session import FileSessionManager
-from tac import TAC, TACConfig
+from tac import TAC
 from tac.channels.sms import SMSChannelConfig
 from tac.channels.voice import VoiceChannelConfig
 from tac.core.logging import get_logger
 from tac.models.session import ConversationSession
+from tac_config import create_tac_config
 
 from tac_aws.connectors import StrandsConnector
 
 logger = get_logger(__name__)
 
-# Initialize TAC
-tac = TAC(config=TACConfig.from_env())
+# Initialize TAC with credentials from Secrets Manager
+tac = TAC(config=create_tac_config())
 
 
 def create_agent(context: ConversationSession) -> Agent:

--- a/deploy/agentcore_aws_lambda/agent/tac_config.py
+++ b/deploy/agentcore_aws_lambda/agent/tac_config.py
@@ -42,7 +42,7 @@ def get_twilio_credentials() -> dict:
     try:
         response = secrets_client.get_secret_value(SecretId=secret_arn)
         credentials = json.loads(response["SecretString"])
-        logger.info(f"Successfully loaded Twilio credentials from Secrets Manager: {secret_arn}")
+        logger.info("Successfully loaded Twilio credentials from Secrets Manager")
         return credentials
     except Exception as e:
         logger.error(f"Failed to fetch Twilio credentials from Secrets Manager: {e}", exc_info=True)

--- a/deploy/agentcore_aws_lambda/agent/tac_config.py
+++ b/deploy/agentcore_aws_lambda/agent/tac_config.py
@@ -26,7 +26,7 @@ def get_twilio_credentials() -> dict:
 
 
 def create_tac_config() -> TACConfig:
-    """Create TACConfig from credentials stored in AWS Secrets Manager."""
+    """Create TACConfig from Secrets Manager (credentials) and environment variables (configuration)."""
     credentials = get_twilio_credentials()
 
     return TACConfig(
@@ -34,6 +34,6 @@ def create_tac_config() -> TACConfig:
         auth_token=credentials["TWILIO_AUTH_TOKEN"],
         api_key=credentials["TWILIO_API_KEY"],
         api_secret=credentials["TWILIO_API_SECRET"],
-        phone_number=credentials["TWILIO_PHONE_NUMBER"],
-        conversation_configuration_id=credentials["TWILIO_CONVERSATION_CONFIGURATION_ID"],
+        phone_number=os.environ["TWILIO_PHONE_NUMBER"],
+        conversation_configuration_id=os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"],
     )

--- a/deploy/agentcore_aws_lambda/agent/tac_config.py
+++ b/deploy/agentcore_aws_lambda/agent/tac_config.py
@@ -1,0 +1,72 @@
+"""
+Secrets Manager integration for TAC AgentCore deployment.
+
+Fetches Twilio credentials from AWS Secrets Manager and provides
+them for TAC configuration.
+"""
+
+import json
+import os
+
+import boto3
+from tac import TACConfig
+from tac.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def get_twilio_credentials() -> dict:
+    """
+    Fetch Twilio credentials from AWS Secrets Manager.
+
+    Uses TWILIO_SECRET_ARN environment variable to locate the secret.
+
+    Returns:
+        dict: Twilio credentials dictionary with keys:
+            - TWILIO_ACCOUNT_SID
+            - TWILIO_AUTH_TOKEN
+            - TWILIO_API_KEY
+            - TWILIO_API_SECRET
+            - TWILIO_PHONE_NUMBER
+            - TWILIO_CONVERSATION_CONFIGURATION_ID
+
+    Raises:
+        KeyError: If TWILIO_SECRET_ARN environment variable is not set
+        Exception: If secret retrieval fails
+    """
+    secret_arn = os.environ["TWILIO_SECRET_ARN"]
+    aws_region = os.environ.get("AWS_REGION", "us-east-1")
+
+    secrets_client = boto3.client("secretsmanager", region_name=aws_region)
+
+    try:
+        response = secrets_client.get_secret_value(SecretId=secret_arn)
+        credentials = json.loads(response["SecretString"])
+        logger.info(f"Successfully loaded Twilio credentials from Secrets Manager: {secret_arn}")
+        return credentials
+    except Exception as e:
+        logger.error(f"Failed to fetch Twilio credentials from Secrets Manager: {e}", exc_info=True)
+        raise
+
+
+def create_tac_config() -> TACConfig:
+    """
+    Create TACConfig from credentials stored in AWS Secrets Manager.
+
+    Returns:
+        TACConfig: Configured TAC instance ready for use
+
+    Raises:
+        KeyError: If TWILIO_SECRET_ARN is not set
+        Exception: If secret retrieval or config creation fails
+    """
+    credentials = get_twilio_credentials()
+
+    return TACConfig(
+        account_sid=credentials["TWILIO_ACCOUNT_SID"],
+        auth_token=credentials["TWILIO_AUTH_TOKEN"],
+        api_key=credentials["TWILIO_API_KEY"],
+        api_secret=credentials["TWILIO_API_SECRET"],
+        phone_number=credentials["TWILIO_PHONE_NUMBER"],
+        conversation_configuration_id=credentials["TWILIO_CONVERSATION_CONFIGURATION_ID"],
+    )

--- a/deploy/agentcore_aws_lambda/agent/tac_config.py
+++ b/deploy/agentcore_aws_lambda/agent/tac_config.py
@@ -1,9 +1,4 @@
-"""
-Secrets Manager integration for TAC AgentCore deployment.
-
-Fetches Twilio credentials from AWS Secrets Manager and provides
-them for TAC configuration.
-"""
+"""Secrets Manager integration for TAC AgentCore deployment."""
 
 import json
 import os
@@ -16,28 +11,9 @@ logger = get_logger(__name__)
 
 
 def get_twilio_credentials() -> dict:
-    """
-    Fetch Twilio credentials from AWS Secrets Manager.
-
-    Uses TWILIO_SECRET_ARN environment variable to locate the secret.
-
-    Returns:
-        dict: Twilio credentials dictionary with keys:
-            - TWILIO_ACCOUNT_SID
-            - TWILIO_AUTH_TOKEN
-            - TWILIO_API_KEY
-            - TWILIO_API_SECRET
-            - TWILIO_PHONE_NUMBER
-            - TWILIO_CONVERSATION_CONFIGURATION_ID
-
-    Raises:
-        KeyError: If TWILIO_SECRET_ARN environment variable is not set
-        Exception: If secret retrieval fails
-    """
+    """Fetch Twilio credentials from AWS Secrets Manager."""
     secret_arn = os.environ["TWILIO_SECRET_ARN"]
-    aws_region = os.environ.get("AWS_REGION", "us-east-1")
-
-    secrets_client = boto3.client("secretsmanager", region_name=aws_region)
+    secrets_client = boto3.client("secretsmanager")
 
     try:
         response = secrets_client.get_secret_value(SecretId=secret_arn)
@@ -50,16 +26,7 @@ def get_twilio_credentials() -> dict:
 
 
 def create_tac_config() -> TACConfig:
-    """
-    Create TACConfig from credentials stored in AWS Secrets Manager.
-
-    Returns:
-        TACConfig: Configured TAC instance ready for use
-
-    Raises:
-        KeyError: If TWILIO_SECRET_ARN is not set
-        Exception: If secret retrieval or config creation fails
-    """
+    """Create TACConfig from credentials stored in AWS Secrets Manager."""
     credentials = get_twilio_credentials()
 
     return TACConfig(

--- a/deploy/agentcore_aws_lambda/agent/tac_config.py
+++ b/deploy/agentcore_aws_lambda/agent/tac_config.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 def get_twilio_credentials() -> dict:
     """Fetch Twilio credentials from AWS Secrets Manager."""
     secret_arn = os.environ["TWILIO_SECRET_ARN"]
-    secrets_client = boto3.client("secretsmanager")
+    secrets_client = boto3.client("secretsmanager", region_name=os.environ["AWS_REGION"])
 
     try:
         response = secrets_client.get_secret_value(SecretId=secret_arn)

--- a/deploy/agentcore_aws_lambda/cdk/bin/app.ts
+++ b/deploy/agentcore_aws_lambda/cdk/bin/app.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { AgentCoreStack } from '../lib/agentcore-stack';
 import { LambdaStack } from '../lib/lambda-stack';
+import { SecretsStack } from '../lib/secrets-stack';
 import { ConfigIO } from '@aws/agentcore-cdk';
 import { App } from 'aws-cdk-lib';
 import * as path from 'path';
-import { loadEnvConfig, toAgentCoreEnvVars } from '../config/env-config';
+import { loadEnvConfig } from '../config/env-config';
 
 async function main() {
   const configRoot = path.join(process.cwd(), 'agentcore');
@@ -12,20 +13,32 @@ async function main() {
   const envConfig = loadEnvConfig(process.cwd());
   const spec = await configIO.readProjectSpec();
 
-  // Inject Twilio credentials as env vars into AgentCore runtime
-  const twilioEnvVars = toAgentCoreEnvVars(envConfig);
+  const app = new App();
+
+  // Create Secrets Manager stack (first - other stacks depend on it)
+  const secretsStack = new SecretsStack(app, 'TacSecretsStack', {
+    env: {
+      account: envConfig.awsAccountId,
+      region: envConfig.awsRegion,
+    },
+    description: 'TAC Secrets Manager for Twilio credentials',
+  });
+
+  // Inject secret ARN as env var into AgentCore runtime
   const enhancedSpec = {
     ...spec,
     runtimes: spec.runtimes.map(runtime => ({
       ...runtime,
-      envVars: [...(runtime.envVars || []), ...twilioEnvVars]
+      envVars: [
+        ...(runtime.envVars || []),
+        { name: 'TWILIO_SECRET_ARN', value: secretsStack.twilioSecret.secretArn },
+      ]
     }))
   };
 
-  const app = new App();
-
   const agentCoreStack = new AgentCoreStack(app, 'TacAgentCoreStack', {
     spec: enhancedSpec,
+    twilioSecret: secretsStack.twilioSecret,
     env: {
       account: envConfig.awsAccountId,
       region: envConfig.awsRegion,
@@ -39,8 +52,7 @@ async function main() {
 
   const lambdaStack = new LambdaStack(app, 'TacLambdaStack', {
     agentCoreRuntimeArn: agentCoreStack.runtimeArn,
-    twilioConversationConfigurationId: envConfig.twilioConversationConfigurationId,
-    twilioAuthToken: envConfig.twilioAuthToken,
+    twilioSecret: secretsStack.twilioSecret,
     env: {
       account: envConfig.awsAccountId,
       region: envConfig.awsRegion,
@@ -48,7 +60,8 @@ async function main() {
     description: 'TAC Lambda Webhook Proxy for Twilio Agent Connect',
   });
 
-  // Lambda must deploy after AgentCore to use runtime ARN
+  // Stack dependencies
+  agentCoreStack.addDependency(secretsStack);
   lambdaStack.addDependency(agentCoreStack);
 
   app.synth();

--- a/deploy/agentcore_aws_lambda/cdk/bin/app.ts
+++ b/deploy/agentcore_aws_lambda/cdk/bin/app.ts
@@ -24,7 +24,7 @@ async function main() {
     description: 'TAC Secrets Manager for Twilio credentials',
   });
 
-  // Inject secret ARN as env var into AgentCore runtime
+  // Inject secret ARN and region as env vars into AgentCore runtime
   const enhancedSpec = {
     ...spec,
     runtimes: spec.runtimes.map(runtime => ({
@@ -32,6 +32,7 @@ async function main() {
       envVars: [
         ...(runtime.envVars || []),
         { name: 'TWILIO_SECRET_ARN', value: secretsStack.twilioSecret.secretArn },
+        { name: 'AWS_REGION', value: envConfig.awsRegion },
       ]
     }))
   };

--- a/deploy/agentcore_aws_lambda/cdk/bin/app.ts
+++ b/deploy/agentcore_aws_lambda/cdk/bin/app.ts
@@ -24,7 +24,7 @@ async function main() {
     description: 'TAC Secrets Manager for Twilio credentials',
   });
 
-  // Inject secret ARN and region as env vars into AgentCore runtime
+  // Inject secret ARN, region, and Twilio configuration as env vars into AgentCore runtime
   const enhancedSpec = {
     ...spec,
     runtimes: spec.runtimes.map(runtime => ({
@@ -33,6 +33,8 @@ async function main() {
         ...(runtime.envVars || []),
         { name: 'TWILIO_SECRET_ARN', value: secretsStack.twilioSecret.secretArn },
         { name: 'AWS_REGION', value: envConfig.awsRegion },
+        { name: 'TWILIO_PHONE_NUMBER', value: envConfig.twilioPhoneNumber },
+        { name: 'TWILIO_CONVERSATION_CONFIGURATION_ID', value: envConfig.twilioConversationConfigurationId },
       ]
     }))
   };
@@ -54,6 +56,7 @@ async function main() {
   const lambdaStack = new LambdaStack(app, 'TacLambdaStack', {
     agentCoreRuntimeArn: agentCoreStack.runtimeArn,
     twilioSecret: secretsStack.twilioSecret,
+    twilioConversationConfigurationId: envConfig.twilioConversationConfigurationId,
     env: {
       account: envConfig.awsAccountId,
       region: envConfig.awsRegion,

--- a/deploy/agentcore_aws_lambda/cdk/config/env-config.ts
+++ b/deploy/agentcore_aws_lambda/cdk/config/env-config.ts
@@ -10,6 +10,9 @@ export interface TacEnvConfig {
   // AWS Configuration
   awsAccountId: string;
   awsRegion: string;
+  // Twilio Configuration (non-secret)
+  twilioPhoneNumber: string;
+  twilioConversationConfigurationId: string;
 }
 
 /**
@@ -29,6 +32,8 @@ export function loadEnvConfig(configRoot: string): TacEnvConfig {
   const requiredVars = [
     'AWS_ACCOUNT_ID',
     'AWS_REGION',
+    'TWILIO_PHONE_NUMBER',
+    'TWILIO_CONVERSATION_CONFIGURATION_ID',
   ];
 
   const missingVars = requiredVars.filter(varName => !process.env[varName]);
@@ -44,6 +49,8 @@ export function loadEnvConfig(configRoot: string): TacEnvConfig {
   return {
     awsAccountId: process.env.AWS_ACCOUNT_ID!,
     awsRegion: process.env.AWS_REGION!,
+    twilioPhoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+    twilioConversationConfigurationId: process.env.TWILIO_CONVERSATION_CONFIGURATION_ID!,
   };
 }
 

--- a/deploy/agentcore_aws_lambda/cdk/config/env-config.ts
+++ b/deploy/agentcore_aws_lambda/cdk/config/env-config.ts
@@ -10,15 +10,6 @@ export interface TacEnvConfig {
   // AWS Configuration
   awsAccountId: string;
   awsRegion: string;
-
-  // Twilio Configuration
-  twilioAccountSid: string;
-  twilioAuthToken: string;
-  twilioApiKey: string;
-  twilioApiSecret: string;
-  twilioPhoneNumber: string;
-  twilioConversationConfigurationId: string;
-  twilioLogLevel: string;
 }
 
 /**
@@ -38,12 +29,6 @@ export function loadEnvConfig(configRoot: string): TacEnvConfig {
   const requiredVars = [
     'AWS_ACCOUNT_ID',
     'AWS_REGION',
-    'TWILIO_ACCOUNT_SID',
-    'TWILIO_AUTH_TOKEN',
-    'TWILIO_API_KEY',
-    'TWILIO_API_SECRET',
-    'TWILIO_PHONE_NUMBER',
-    'TWILIO_CONVERSATION_CONFIGURATION_ID',
   ];
 
   const missingVars = requiredVars.filter(varName => !process.env[varName]);
@@ -59,30 +44,6 @@ export function loadEnvConfig(configRoot: string): TacEnvConfig {
   return {
     awsAccountId: process.env.AWS_ACCOUNT_ID!,
     awsRegion: process.env.AWS_REGION!,
-    twilioAccountSid: process.env.TWILIO_ACCOUNT_SID!,
-    twilioAuthToken: process.env.TWILIO_AUTH_TOKEN!,
-    twilioApiKey: process.env.TWILIO_API_KEY!,
-    twilioApiSecret: process.env.TWILIO_API_SECRET!,
-    twilioPhoneNumber: process.env.TWILIO_PHONE_NUMBER!,
-    twilioConversationConfigurationId: process.env.TWILIO_CONVERSATION_CONFIGURATION_ID!,
-    twilioLogLevel: process.env.TWILIO_LOG_LEVEL || 'INFO',
   };
 }
 
-/**
- * Converts TacEnvConfig to AgentCore envVars format.
- *
- * @param config - Validated environment configuration
- * @returns Array of environment variables for AgentCore runtime
- */
-export function toAgentCoreEnvVars(config: TacEnvConfig): Array<{ name: string; value: string }> {
-  return [
-    { name: 'TWILIO_ACCOUNT_SID', value: config.twilioAccountSid },
-    { name: 'TWILIO_AUTH_TOKEN', value: config.twilioAuthToken },
-    { name: 'TWILIO_API_KEY', value: config.twilioApiKey },
-    { name: 'TWILIO_API_SECRET', value: config.twilioApiSecret },
-    { name: 'TWILIO_PHONE_NUMBER', value: config.twilioPhoneNumber },
-    { name: 'TWILIO_CONVERSATION_CONFIGURATION_ID', value: config.twilioConversationConfigurationId },
-    { name: 'TWILIO_LOG_LEVEL', value: config.twilioLogLevel },
-  ];
-}

--- a/deploy/agentcore_aws_lambda/cdk/lib/agentcore-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/agentcore-stack.ts
@@ -57,16 +57,11 @@ export class AgentCoreStack extends Stack {
     // Grant AgentCore runtime permission to read Twilio credentials
     props.twilioSecret.grantRead(environment.runtime.role);
 
-    // Stack-level outputs
-    new CfnOutput(this, 'StackNameOutput', {
-      description: 'Name of the CloudFormation Stack',
-      value: this.stackName,
-    });
-
+    // Output runtime ARN for Lambda stack
     new CfnOutput(this, 'AgentCoreRuntimeArn', {
       description: 'AgentCore Runtime ARN',
       value: this.runtimeArn,
-      exportName: 'TacAgentCoreRuntimeArn',  // Export for cross-stack reference
+      exportName: 'TacAgentCoreRuntimeArn',
     });
   }
 }

--- a/deploy/agentcore_aws_lambda/cdk/lib/agentcore-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/agentcore-stack.ts
@@ -3,6 +3,7 @@ import {
   type AgentCoreProjectSpec,
 } from '@aws/agentcore-cdk';
 import { CfnOutput, Stack, type StackProps } from 'aws-cdk-lib';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 
 export interface AgentCoreStackProps extends StackProps {
@@ -10,6 +11,11 @@ export interface AgentCoreStackProps extends StackProps {
    * The AgentCore project specification containing agents, memories, and credentials.
    */
   spec: AgentCoreProjectSpec;
+
+  /**
+   * Twilio credentials secret (for granting read access to AgentCore runtime)
+   */
+  twilioSecret: secretsmanager.ISecret;
 }
 
 /**
@@ -47,6 +53,9 @@ export class AgentCoreStack extends Stack {
     }
 
     this.runtimeArn = environment.runtime.runtimeArn;
+
+    // Grant AgentCore runtime permission to read Twilio credentials
+    props.twilioSecret.grantRead(environment.runtime.role);
 
     // Stack-level outputs
     new CfnOutput(this, 'StackNameOutput', {

--- a/deploy/agentcore_aws_lambda/cdk/lib/lambda-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/lambda-stack.ts
@@ -1,13 +1,13 @@
 import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 import { PythonFunction } from '@aws-cdk/aws-lambda-python-alpha';
 
 export interface LambdaStackProps extends cdk.StackProps {
   agentCoreRuntimeArn: string;
-  twilioConversationConfigurationId: string;
-  twilioAuthToken: string;
+  twilioSecret: secretsmanager.ISecret;
 }
 
 export class LambdaStack extends cdk.Stack {
@@ -24,10 +24,12 @@ export class LambdaStack extends cdk.Stack {
       memorySize: 1024,
       environment: {
         AGENTCORE_RUNTIME_ARN: props.agentCoreRuntimeArn,
-        TWILIO_CONVERSATION_CONFIGURATION_ID: props.twilioConversationConfigurationId,
-        TWILIO_AUTH_TOKEN: props.twilioAuthToken,
+        TWILIO_SECRET_ARN: props.twilioSecret.secretArn,
       },
     });
+
+    // Grant Lambda permission to read Twilio credentials and config from Secrets Manager
+    props.twilioSecret.grantRead(lambdaFunction);
 
     // Grant permissions to invoke AgentCore
     // InvokeAgentRuntime: For SMS HTTP invocations

--- a/deploy/agentcore_aws_lambda/cdk/lib/lambda-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/lambda-stack.ts
@@ -8,6 +8,7 @@ import { PythonFunction } from '@aws-cdk/aws-lambda-python-alpha';
 export interface LambdaStackProps extends cdk.StackProps {
   agentCoreRuntimeArn: string;
   twilioSecret: secretsmanager.ISecret;
+  twilioConversationConfigurationId: string;
 }
 
 export class LambdaStack extends cdk.Stack {
@@ -25,10 +26,11 @@ export class LambdaStack extends cdk.Stack {
       environment: {
         AGENTCORE_RUNTIME_ARN: props.agentCoreRuntimeArn,
         TWILIO_SECRET_ARN: props.twilioSecret.secretArn,
+        TWILIO_CONVERSATION_CONFIGURATION_ID: props.twilioConversationConfigurationId,
       },
     });
 
-    // Grant Lambda permission to read Twilio credentials and config from Secrets Manager
+    // Grant Lambda permission to read Twilio credentials from Secrets Manager
     props.twilioSecret.grantRead(lambdaFunction);
 
     // Grant permissions to invoke AgentCore
@@ -61,11 +63,6 @@ export class LambdaStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'ConversationWebhookUrl', {
       value: `${functionUrl.url}webhook`,
       description: 'Twilio Conversation Webhook URL',
-    });
-
-    new cdk.CfnOutput(this, 'FunctionArn', {
-      value: lambdaFunction.functionArn,
-      description: 'Lambda Function ARN',
     });
   }
 }

--- a/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
@@ -9,21 +9,13 @@ export class SecretsStack extends cdk.Stack {
     super(scope, id, props);
 
     // Create secret resource with placeholder value (overwritten by 'make secret-update')
+    // RETAIN prevents accidental credential deletion when stack is deleted/replaced.
+    // Note: If you delete the stack and redeploy, you must first manually delete the secret:
+    //   aws secretsmanager delete-secret --secret-id tac/twilio-credentials --region <region>
     this.twilioSecret = new secretsmanager.Secret(this, 'TwilioCredentials', {
       secretName: 'tac/twilio-credentials',
       description: 'Twilio credentials and configuration for TAC',
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    });
-
-    // Output secret ARN for cross-stack references
-    new cdk.CfnOutput(this, 'SecretArn', {
-      value: this.twilioSecret.secretArn,
-      description: 'Twilio credentials secret ARN',
-    });
-
-    new cdk.CfnOutput(this, 'SecretName', {
-      value: this.twilioSecret.secretName,
-      description: 'Twilio credentials secret name',
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
   }
 }

--- a/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
@@ -8,10 +8,11 @@ export class SecretsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // Create empty secret resource (populated via 'make secret-update' after deployment)
+    // Create secret resource with placeholder value (overwritten by 'make secret-update')
     this.twilioSecret = new secretsmanager.Secret(this, 'TwilioCredentials', {
       secretName: 'tac/twilio-credentials',
       description: 'Twilio credentials and configuration for TAC',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     // Output secret ARN for cross-stack references

--- a/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
@@ -8,14 +8,12 @@ export class SecretsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // Create secret resource with placeholder value (overwritten by 'make secret-update')
-    // RETAIN prevents accidental credential deletion when stack is deleted/replaced.
-    // Note: If you delete the stack and redeploy, you must first manually delete the secret:
-    //   aws secretsmanager delete-secret --secret-id tac/twilio-credentials --region <region>
+    // Secret with placeholder value (populated by 'make secret-update')
+    // DESTROY policy allows clean redeploy. Credentials are in .env and can be restored.
     this.twilioSecret = new secretsmanager.Secret(this, 'TwilioCredentials', {
       secretName: 'tac/twilio-credentials',
-      description: 'Twilio credentials and configuration for TAC',
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      description: 'Twilio credentials for TAC',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
   }
 }

--- a/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
@@ -8,19 +8,10 @@ export class SecretsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // Create secret with placeholder values
-    // Real values populated via 'make secret-update' after deployment
+    // Create empty secret resource (populated via 'make secret-update' after deployment)
     this.twilioSecret = new secretsmanager.Secret(this, 'TwilioCredentials', {
       secretName: 'tac/twilio-credentials',
-      description: 'Twilio credentials and configuration for TAC (auto-updated by make deploy)',
-      secretObjectValue: {
-        TWILIO_ACCOUNT_SID: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
-        TWILIO_AUTH_TOKEN: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
-        TWILIO_API_KEY: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
-        TWILIO_API_SECRET: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
-        TWILIO_PHONE_NUMBER: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
-        TWILIO_CONVERSATION_CONFIGURATION_ID: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
-      },
+      description: 'Twilio credentials and configuration for TAC',
     });
 
     // Output secret ARN for cross-stack references

--- a/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
+++ b/deploy/agentcore_aws_lambda/cdk/lib/secrets-stack.ts
@@ -1,0 +1,37 @@
+import * as cdk from 'aws-cdk-lib';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { Construct } from 'constructs';
+
+export class SecretsStack extends cdk.Stack {
+  public readonly twilioSecret: secretsmanager.ISecret;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Create secret with placeholder values
+    // Real values populated via 'make secret-update' after deployment
+    this.twilioSecret = new secretsmanager.Secret(this, 'TwilioCredentials', {
+      secretName: 'tac/twilio-credentials',
+      description: 'Twilio credentials and configuration for TAC (auto-updated by make deploy)',
+      secretObjectValue: {
+        TWILIO_ACCOUNT_SID: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
+        TWILIO_AUTH_TOKEN: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
+        TWILIO_API_KEY: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
+        TWILIO_API_SECRET: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
+        TWILIO_PHONE_NUMBER: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
+        TWILIO_CONVERSATION_CONFIGURATION_ID: cdk.SecretValue.unsafePlainText('PLACEHOLDER'),
+      },
+    });
+
+    // Output secret ARN for cross-stack references
+    new cdk.CfnOutput(this, 'SecretArn', {
+      value: this.twilioSecret.secretArn,
+      description: 'Twilio credentials secret ARN',
+    });
+
+    new cdk.CfnOutput(this, 'SecretName', {
+      value: this.twilioSecret.secretName,
+      description: 'Twilio credentials secret name',
+    });
+  }
+}

--- a/deploy/agentcore_aws_lambda/iam-policy.json
+++ b/deploy/agentcore_aws_lambda/iam-policy.json
@@ -161,6 +161,21 @@
       "Effect": "Allow",
       "Action": "sts:AssumeRole",
       "Resource": "arn:aws:iam::*:role/cdk-*"
+    },
+    {
+      "Sid": "SecretsManager",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:TagResource",
+        "secretsmanager:UntagResource"
+      ],
+      "Resource": "arn:aws:secretsmanager:*:*:secret:tac/twilio-credentials*"
     }
   ]
 }

--- a/deploy/agentcore_aws_lambda/iam-policy.json
+++ b/deploy/agentcore_aws_lambda/iam-policy.json
@@ -163,10 +163,20 @@
       "Resource": "arn:aws:iam::*:role/cdk-*"
     },
     {
-      "Sid": "SecretsManagerDeploy",
+      "Sid": "SecretsManagerCreate",
+      "Effect": "Allow",
+      "Action": "secretsmanager:CreateSecret",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "secretsmanager:Name": "tac/twilio-credentials"
+        }
+      }
+    },
+    {
+      "Sid": "SecretsManagerUpdate",
       "Effect": "Allow",
       "Action": [
-        "secretsmanager:CreateSecret",
         "secretsmanager:DescribeSecret",
         "secretsmanager:PutSecretValue",
         "secretsmanager:TagResource"

--- a/deploy/agentcore_aws_lambda/iam-policy.json
+++ b/deploy/agentcore_aws_lambda/iam-policy.json
@@ -163,17 +163,13 @@
       "Resource": "arn:aws:iam::*:role/cdk-*"
     },
     {
-      "Sid": "SecretsManager",
+      "Sid": "SecretsManagerDeploy",
       "Effect": "Allow",
       "Action": [
         "secretsmanager:CreateSecret",
-        "secretsmanager:DeleteSecret",
         "secretsmanager:DescribeSecret",
-        "secretsmanager:GetSecretValue",
         "secretsmanager:PutSecretValue",
-        "secretsmanager:UpdateSecret",
-        "secretsmanager:TagResource",
-        "secretsmanager:UntagResource"
+        "secretsmanager:TagResource"
       ],
       "Resource": "arn:aws:secretsmanager:*:*:secret:tac/twilio-credentials*"
     }

--- a/deploy/agentcore_aws_lambda/lambda/index.py
+++ b/deploy/agentcore_aws_lambda/lambda/index.py
@@ -57,13 +57,14 @@ def get_twilio_credentials():
         response = secrets_client.get_secret_value(SecretId=TWILIO_SECRET_ARN)
         credentials = json.loads(response["SecretString"])
 
-        # Validate credentials aren't placeholders
-        for key, value in credentials.items():
-            if str(value).startswith("PLACEHOLDER_"):
-                raise ValueError(
-                    f"Secret contains placeholder value for {key}. "
-                    f"Run 'make secret-update' to set real Twilio credentials."
-                )
+        # Validate required credentials have non-empty values
+        if not credentials.get("TWILIO_AUTH_TOKEN") or not credentials.get(
+            "TWILIO_CONVERSATION_CONFIGURATION_ID"
+        ):
+            raise ValueError(
+                "Secret missing or empty credentials. "
+                "Run 'make secret-update' to populate Twilio credentials."
+            )
 
         # Cache for future invocations
         _twilio_credentials = credentials

--- a/deploy/agentcore_aws_lambda/lambda/index.py
+++ b/deploy/agentcore_aws_lambda/lambda/index.py
@@ -20,6 +20,7 @@ logger = get_logger(__name__)
 # Environment variables
 AGENTCORE_RUNTIME_ARN = os.environ["AGENTCORE_RUNTIME_ARN"]
 TWILIO_SECRET_ARN = os.environ["TWILIO_SECRET_ARN"]
+TWILIO_CONVERSATION_CONFIGURATION_ID = os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"]
 AWS_REGION = os.environ["AWS_REGION"]
 
 # Initialize clients
@@ -35,11 +36,9 @@ def _fetch_twilio_credentials():
         credentials = json.loads(response["SecretString"])
 
         # Validate required credentials have non-empty values
-        if not credentials.get("TWILIO_AUTH_TOKEN") or not credentials.get(
-            "TWILIO_CONVERSATION_CONFIGURATION_ID"
-        ):
+        if not credentials.get("TWILIO_AUTH_TOKEN"):
             raise ValueError(
-                "Secret missing or empty credentials. "
+                "Secret missing TWILIO_AUTH_TOKEN. "
                 "Run 'make secret-update' to populate Twilio credentials."
             )
 
@@ -99,9 +98,7 @@ def handle_voice_twiml(event):
         twiml = generate_twiml(
             options={
                 "websocket_url": websocket_url,
-                "conversation_configuration": twilio_credentials[
-                    "TWILIO_CONVERSATION_CONFIGURATION_ID"
-                ],
+                "conversation_configuration": TWILIO_CONVERSATION_CONFIGURATION_ID,
             }
         )
 

--- a/deploy/agentcore_aws_lambda/lambda/index.py
+++ b/deploy/agentcore_aws_lambda/lambda/index.py
@@ -19,13 +19,31 @@ logger = get_logger(__name__)
 
 # Environment variables
 AGENTCORE_RUNTIME_ARN = os.environ["AGENTCORE_RUNTIME_ARN"]
-TWILIO_CONVERSATION_CONFIGURATION_ID = os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"]
-TWILIO_AUTH_TOKEN = os.environ["TWILIO_AUTH_TOKEN"]
+TWILIO_SECRET_ARN = os.environ["TWILIO_SECRET_ARN"]
 AWS_REGION = os.environ["AWS_REGION"]
 
 # Initialize clients
 agent_core_client = boto3.client("bedrock-agentcore")
 agentcore_runtime_client = AgentCoreRuntimeClient(region=AWS_REGION)
+secrets_client = boto3.client("secretsmanager", region_name=AWS_REGION)
+
+
+def get_twilio_credentials():
+    """Fetch Twilio credentials from Secrets Manager."""
+    try:
+        response = secrets_client.get_secret_value(SecretId=TWILIO_SECRET_ARN)
+        return json.loads(response["SecretString"])
+    except Exception as e:
+        logger.error(f"Failed to fetch Twilio credentials from Secrets Manager: {e}", exc_info=True)
+        raise
+
+
+# Fetch credentials once at cold start
+twilio_credentials = get_twilio_credentials()
+TWILIO_AUTH_TOKEN = twilio_credentials["TWILIO_AUTH_TOKEN"]
+TWILIO_CONVERSATION_CONFIGURATION_ID = twilio_credentials["TWILIO_CONVERSATION_CONFIGURATION_ID"]
+
+# Initialize signature validator with auth token
 signature_validator = TwilioSignatureValidator(TWILIO_AUTH_TOKEN)
 
 

--- a/deploy/agentcore_aws_lambda/lambda/index.py
+++ b/deploy/agentcore_aws_lambda/lambda/index.py
@@ -27,30 +27,70 @@ agent_core_client = boto3.client("bedrock-agentcore")
 agentcore_runtime_client = AgentCoreRuntimeClient(region=AWS_REGION)
 secrets_client = boto3.client("secretsmanager", region_name=AWS_REGION)
 
+# Module-level cache for credentials (lazy loaded on first invocation)
+_twilio_credentials = None
+_signature_validator = None
+
 
 def get_twilio_credentials():
-    """Fetch Twilio credentials from Secrets Manager."""
+    """
+    Fetch and validate Twilio credentials from Secrets Manager (cached).
+
+    Credentials are fetched lazily on first invocation and cached for subsequent requests.
+    This approach allows transient Secrets Manager errors to recover on retry rather than
+    bricking the Lambda execution environment during cold start.
+
+    Returns:
+        dict: Validated Twilio credentials
+
+    Raises:
+        ValueError: If secret contains placeholder values or missing keys
+        Exception: If secret retrieval fails
+    """
+    global _twilio_credentials
+
+    # Return cached value if available
+    if _twilio_credentials is not None:
+        return _twilio_credentials
+
     try:
         response = secrets_client.get_secret_value(SecretId=TWILIO_SECRET_ARN)
-        return json.loads(response["SecretString"])
+        credentials = json.loads(response["SecretString"])
+
+        # Validate credentials aren't placeholders
+        for key, value in credentials.items():
+            if str(value).startswith("PLACEHOLDER_"):
+                raise ValueError(
+                    f"Secret contains placeholder value for {key}. "
+                    f"Run 'make secret-update' to set real Twilio credentials."
+                )
+
+        # Cache for future invocations
+        _twilio_credentials = credentials
+        logger.info("Successfully loaded and validated Twilio credentials from Secrets Manager")
+        return credentials
+
     except Exception as e:
         logger.error(f"Failed to fetch Twilio credentials from Secrets Manager: {e}", exc_info=True)
         raise
 
 
-# Fetch credentials once at cold start
-twilio_credentials = get_twilio_credentials()
-TWILIO_AUTH_TOKEN = twilio_credentials["TWILIO_AUTH_TOKEN"]
-TWILIO_CONVERSATION_CONFIGURATION_ID = twilio_credentials["TWILIO_CONVERSATION_CONFIGURATION_ID"]
+def get_signature_validator():
+    """Get TwilioSignatureValidator instance (cached, initialized lazily)."""
+    global _signature_validator
 
-# Initialize signature validator with auth token
-signature_validator = TwilioSignatureValidator(TWILIO_AUTH_TOKEN)
+    if _signature_validator is None:
+        credentials = get_twilio_credentials()
+        _signature_validator = TwilioSignatureValidator(credentials["TWILIO_AUTH_TOKEN"])
+
+    return _signature_validator
 
 
 def lambda_handler(event, context):
     """Route requests to appropriate handler."""
-    # Validate Twilio signature
-    if not signature_validator.validate(event):
+    # Validate Twilio signature (lazy loads credentials on first invocation)
+    validator = get_signature_validator()
+    if not validator.validate(event):
         return {
             "statusCode": 403,
             "headers": {"Content-Type": "application/json"},
@@ -89,10 +129,11 @@ def handle_voice_twiml(event):
             runtime_arn=AGENTCORE_RUNTIME_ARN, session_id=call_sid, expires=300
         )
 
+        credentials = get_twilio_credentials()
         twiml = generate_twiml(
             options={
                 "websocket_url": websocket_url,
-                "conversation_configuration": TWILIO_CONVERSATION_CONFIGURATION_ID,
+                "conversation_configuration": credentials["TWILIO_CONVERSATION_CONFIGURATION_ID"],
             }
         )
 

--- a/deploy/agentcore_aws_lambda/lambda/index.py
+++ b/deploy/agentcore_aws_lambda/lambda/index.py
@@ -27,32 +27,9 @@ agent_core_client = boto3.client("bedrock-agentcore")
 agentcore_runtime_client = AgentCoreRuntimeClient(region=AWS_REGION)
 secrets_client = boto3.client("secretsmanager", region_name=AWS_REGION)
 
-# Module-level cache for credentials (lazy loaded on first invocation)
-_twilio_credentials = None
-_signature_validator = None
 
-
-def get_twilio_credentials():
-    """
-    Fetch and validate Twilio credentials from Secrets Manager (cached).
-
-    Credentials are fetched lazily on first invocation and cached for subsequent requests.
-    This approach allows transient Secrets Manager errors to recover on retry rather than
-    bricking the Lambda execution environment during cold start.
-
-    Returns:
-        dict: Validated Twilio credentials
-
-    Raises:
-        ValueError: If secret contains placeholder values or missing keys
-        Exception: If secret retrieval fails
-    """
-    global _twilio_credentials
-
-    # Return cached value if available
-    if _twilio_credentials is not None:
-        return _twilio_credentials
-
+def _fetch_twilio_credentials():
+    """Fetch Twilio credentials from Secrets Manager."""
     try:
         response = secrets_client.get_secret_value(SecretId=TWILIO_SECRET_ARN)
         credentials = json.loads(response["SecretString"])
@@ -66,32 +43,21 @@ def get_twilio_credentials():
                 "Run 'make secret-update' to populate Twilio credentials."
             )
 
-        # Cache for future invocations
-        _twilio_credentials = credentials
-        logger.info("Successfully loaded and validated Twilio credentials from Secrets Manager")
+        logger.info("Successfully loaded Twilio credentials from Secrets Manager")
         return credentials
 
     except Exception as e:
-        logger.error(f"Failed to fetch Twilio credentials from Secrets Manager: {e}", exc_info=True)
+        logger.error(f"Failed to fetch Twilio credentials: {e}", exc_info=True)
         raise
 
 
-def get_signature_validator():
-    """Get TwilioSignatureValidator instance (cached, initialized lazily)."""
-    global _signature_validator
-
-    if _signature_validator is None:
-        credentials = get_twilio_credentials()
-        _signature_validator = TwilioSignatureValidator(credentials["TWILIO_AUTH_TOKEN"])
-
-    return _signature_validator
+twilio_credentials = _fetch_twilio_credentials()
+signature_validator = TwilioSignatureValidator(twilio_credentials["TWILIO_AUTH_TOKEN"])
 
 
 def lambda_handler(event, context):
     """Route requests to appropriate handler."""
-    # Validate Twilio signature (lazy loads credentials on first invocation)
-    validator = get_signature_validator()
-    if not validator.validate(event):
+    if not signature_validator.validate(event):
         return {
             "statusCode": 403,
             "headers": {"Content-Type": "application/json"},
@@ -130,11 +96,12 @@ def handle_voice_twiml(event):
             runtime_arn=AGENTCORE_RUNTIME_ARN, session_id=call_sid, expires=300
         )
 
-        credentials = get_twilio_credentials()
         twiml = generate_twiml(
             options={
                 "websocket_url": websocket_url,
-                "conversation_configuration": credentials["TWILIO_CONVERSATION_CONFIGURATION_ID"],
+                "conversation_configuration": twilio_credentials[
+                    "TWILIO_CONVERSATION_CONFIGURATION_ID"
+                ],
             }
         )
 


### PR DESCRIPTION
## Summary

Migrate AgentCore Lambda deployment to use AWS Secrets Manager for Twilio credentials with proper separation of secrets and configuration.

## Key Changes

### Security Model
- **Secrets (Secrets Manager)**: Account SID, Auth Token, API Key, API Secret
- **Configuration (Env Vars)**: Phone Number, Conversation Configuration ID
- Credentials stored securely in Secrets Manager, configuration passed at deployment time
- Least-privilege IAM permissions with scoped resource access

### Infrastructure Updates
- ✅ Separate secrets from configuration in both AgentCore and Lambda
- ✅ Change Secrets Manager removal policy from RETAIN to DESTROY for clean redeploys
- ✅ Remove unnecessary stack outputs (AgentCore role ARN, duplicate runtime ARNs)
- ✅ Streamline Makefile commands (remove secret-restore/secret-delete)
- ✅ Add proper environment variable validation in CDK

### Code Improvements
- ✅ Agent (`tac_config.py`): Load credentials from Secrets Manager, config from env vars
- ✅ Lambda (`index.py`): Load credentials from Secrets Manager, config from env vars
- ✅ CDK: Pass phone number and conversation config ID as environment variables
- ✅ Fix import conflict: rename `secrets.py` to `tac_config.py`
- ✅ Module-level credential initialization for simplicity

### Deployment Workflow
- ✅ Simplified deployment: `make deploy` handles everything
- ✅ 3-stage flow: Deploy Secrets → Update credentials → Deploy AgentCore + Lambda
- ✅ Clean destroy/redeploy cycle with DESTROY policy
- ✅ `make secret-update` for credential rotation

## Testing

- ✅ Verified SMS channel with Secrets Manager integration
- ✅ Verified Voice channel with Secrets Manager integration  
- ✅ Tested credential rotation via `make secret-update`
- ✅ Confirmed proper IAM permissions and stack dependencies
- ✅ Validated clean destroy/redeploy cycle

## Commits

1. Initial Secrets Manager migration
2. Security review feedback (IAM, Makefile, logging)
3. Simplify integration and fix security issues
4. Fix comment and credential loading
5. Improve security and reliability
6. Merge main branch
7. **Separate secrets from configuration** (latest)
   - Store only credentials in Secrets Manager
   - Pass configuration as environment variables
   - Change to DESTROY policy for clean redeploys
   - Remove unnecessary Makefile commands and stack outputs

## Migration Guide

For existing deployments:

```bash
# 1. Update .env with all Twilio values
# 2. Deploy with new approach
make deploy

# To rotate credentials:
make secret-update
make deploy
```

With DESTROY policy, `make destroy` cleanly removes all resources including the secret. No manual cleanup needed for redeploys.