### PR TITLE
Update uv.lock for version 1.1.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2181,7 +2181,7 @@ server = [
 
 [[package]]
 name = "twilio-agent-connect-aws"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "twilio-agent-connect" },


### PR DESCRIPTION
Updates lock file to reflect the version bump to 1.1.0 from #45.