### PR TITLE
ci: Fix broken SHA for gh-action-pypi-publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,4 +79,4 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@4cf0fdb7e1623e99dab752bc00bab23c0b69d050 # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Summary

The `pypa/gh-action-pypi-publish` step in `deploy.yml` was pinned to commit SHA `4cf0fdb7e1623e99dab752bc00bab23c0b69d050`, which does not exist in the action's repository. This caused the publish job to fail with:

> Error: Unable to resolve action `pypa/gh-action-pypi-publish@4cf0fdb7...`, unable to find version `4cf0fdb7...`

The bad SHA was introduced when the deploy workflow was first added (#19) and only surfaced now because this is the first time the publish step actually ran. This corrects it to the real commit SHA for the `v1.14.0` tag (`cef221092ed1bacb1cc03d23a2d87d1d172e277b`).

## Type of Change

- [x] Bug fix

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E