### PR TITLE
chore(deps): Upgrade pytest to 9.x and pytest-asyncio to 1.x

### DIFF
--- a/deploy/agentcore_aws_fargate/agent/agent.py
+++ b/deploy/agentcore_aws_fargate/agent/agent.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from strands import Agent
@@ -19,7 +21,7 @@ app = BedrockAgentCoreApp()
 
 
 @app.entrypoint
-async def invoke(payload):
+async def invoke(payload: dict[str, Any]) -> AsyncGenerator[dict[str, Any], None]:
     """HTTP streaming entrypoint - yields tokens for streaming response"""
     user_message = payload.get("prompt", "Hello")
     logger.info(f"HTTP invocation with message: {user_message[:50]}...")
@@ -34,7 +36,7 @@ async def invoke(payload):
 
 
 @app.websocket
-async def websocket_handler(websocket, context):
+async def websocket_handler(websocket: Any, context: Any) -> None:
     """WebSocket entrypoint - low-latency streaming for voice"""
     await websocket.accept()
     logger.info(f"WebSocket connection accepted for session: {context.session_id}")

--- a/deploy/agentcore_aws_lambda/Makefile
+++ b/deploy/agentcore_aws_lambda/Makefile
@@ -3,6 +3,9 @@
 # Load environment variables from .env file
 -include .env
 
+# Load local customizations if present (gitignored; personal testing targets)
+-include Makefile.local
+
 # Unset AWS_PROFILE from shell environment to force reading from .env only
 unexport AWS_PROFILE
 AWS_PROFILE := $(shell grep '^AWS_PROFILE=' .env 2>/dev/null | cut -d '=' -f 2-)

--- a/deploy/agentcore_aws_lambda/agent/tac_config.py
+++ b/deploy/agentcore_aws_lambda/agent/tac_config.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from typing import Any
 
 import boto3
 from tac import TACConfig
@@ -10,14 +11,14 @@ from tac.core.logging import get_logger
 logger = get_logger(__name__)
 
 
-def get_twilio_credentials() -> dict:
+def get_twilio_credentials() -> dict[str, Any]:
     """Fetch Twilio credentials from AWS Secrets Manager."""
     secret_arn = os.environ["TWILIO_SECRET_ARN"]
     secrets_client = boto3.client("secretsmanager", region_name=os.environ["AWS_REGION"])
 
     try:
         response = secrets_client.get_secret_value(SecretId=secret_arn)
-        credentials = json.loads(response["SecretString"])
+        credentials: dict[str, Any] = json.loads(response["SecretString"])
         logger.info("Successfully loaded Twilio credentials from Secrets Manager")
         return credentials
     except Exception as e:

--- a/deploy/agentcore_aws_lambda/lambda/credentials.py
+++ b/deploy/agentcore_aws_lambda/lambda/credentials.py
@@ -50,7 +50,7 @@ def fetch_twilio_auth_token(secret_arn: str, region: str | None = None) -> str:
             )
 
         logger.info("Successfully loaded Twilio auth token from Secrets Manager")
-        return auth_token
+        return str(auth_token)
 
     except Exception as e:
         logger.error(f"Failed to fetch Twilio auth token: {e}", exc_info=True)

--- a/deploy/agentcore_aws_lambda/lambda/credentials.py
+++ b/deploy/agentcore_aws_lambda/lambda/credentials.py
@@ -41,16 +41,16 @@ def fetch_twilio_auth_token(secret_arn: str, region: str | None = None) -> str:
         response = secrets_client.get_secret_value(SecretId=secret_arn)
         credentials = json.loads(response["SecretString"])
 
-        # Validate and extract auth token
+        # Validate and extract auth token: must be a non-empty string
         auth_token = credentials.get("TWILIO_AUTH_TOKEN")
-        if not auth_token:
+        if not isinstance(auth_token, str) or not auth_token:
             raise ValueError(
-                "Secret missing TWILIO_AUTH_TOKEN. "
+                "Secret missing or invalid TWILIO_AUTH_TOKEN (expected a non-empty string). "
                 "Run 'make secret-update' to populate Twilio credentials."
             )
 
         logger.info("Successfully loaded Twilio auth token from Secrets Manager")
-        return str(auth_token)
+        return auth_token
 
     except Exception as e:
         logger.error(f"Failed to fetch Twilio auth token: {e}", exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ dev = [
     # Server dependencies (via TAC core)
     "twilio-agent-connect[server]>=1.0.0,<2",
     # Dev tools
-    "pytest>=7.0.0,<8",
-    "pytest-asyncio>=0.23.0,<1",
+    "pytest>=9.0.0,<10",
+    "pytest-asyncio>=1.0.0,<2",
     "pytest-cov>=5.0.0,<8",
     "ruff>=0.8.0,<1",
     "mypy>=1.0.0,<2",
@@ -161,7 +161,7 @@ module = "twilio.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "9.0"
 addopts = "-ra -q --strict-markers --strict-config"
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "bedrock-agentcore"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1686,6 +1695,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1704,7 +1722,7 @@ crypto = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1712,23 +1730,26 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/b4/0b378b7bf26a8ae161c3890c0b48a91a04106c5713ce81b4b080ea2f4f18/pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3", size = 46920, upload-time = "2024-07-17T17:39:34.617Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/82/62e2d63639ecb0fbe8a7ee59ef0bc69a4669ec50f6d3459f74ad4e4189a2/pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2", size = 17663, upload-time = "2024-07-17T17:39:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -2249,8 +2270,8 @@ requires-dist = [
     { name = "mypy-boto3-bedrock-agent-runtime", marker = "extra == 'dev'", specifier = ">=1.42.0" },
     { name = "mypy-boto3-bedrock-agentcore", marker = "extra == 'agentcore'", specifier = ">=1.42.0" },
     { name = "mypy-boto3-bedrock-agentcore", marker = "extra == 'dev'", specifier = ">=1.42.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0,<8" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0,<1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0,<10" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0,<2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0,<8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0,<1" },
     { name = "strands-agents", marker = "extra == 'dev'", specifier = ">=1.30.0" },


### PR DESCRIPTION
## Summary

Two changes on this branch:

**1. Test toolchain upgrade**
- `pytest` `>=7,<8` → `>=9,<10` (resolves to 9.1.1)
- `pytest-asyncio` `>=0.23,<1` → `>=1,<2` (resolves to 1.4.0)
- Bumps `minversion` in `[tool.pytest.ini_options]` to `9.0`
- Refreshes `uv.lock` (adds `pygments`, `backports-asyncio-runner` transitive deps)
- Adds type annotations to keep the deploy examples clean under the stricter toolchain, and wires a gitignored `Makefile.local` include for local testing targets

**2. Harden Twilio auth token validation** (`deploy/agentcore_aws_lambda/lambda/credentials.py`)
- Validate that the secret value is a non-empty string instead of coercing via `str()`
- Non-string shapes (`None`, numbers, bools, etc.) now raise a clear `ValueError` rather than being silently stringified, avoiding confusing downstream auth failures on misconfiguration

## Type of Change

- [x] Bug fix
- [x] Refactoring
- [x] Build/dependency update

## Checklist

- [x] Tests pass (`make test` — 82 passed)
- [ ] Documentation updated (not needed — dev-tooling / deploy-example only)
- [x] Tested E2E