### PR TITLE
Add .worktreeinclude to copy example .env files into new worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,10 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
+*.env
+.*env
+!.env.example
 .venv
 env/
 venv/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Copy local env files into new worktrees (see .gitignore for what's ignored).
+# Only gitignored matches are copied, so tracked .env.example/.env.template are skipped.
+getting_started/examples/**/.env*


### PR DESCRIPTION
## Summary

New worktrees are fresh checkouts, so gitignored `.env` files under `getting_started/examples/` don't carry over — examples can't run without recreating secrets by hand. This adds a `.worktreeinclude` ([docs](https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees)) that copies them in automatically. It uses gitignore syntax and only copies files that are already gitignored, so tracked `.env.example` files are never duplicated.

Also broadens the `.gitignore` env patterns (`.env.*`, `*.env`, `.*env`) to catch `.env.local`/`.env.development`, keeping `.env.example` tracked via `!.env.example`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E
