### PR TITLE
ci: repin sdk-actions to v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Scan uv.lock + clean-room public install
-        uses: twilio/sdk-actions/uv-lockfile-hygiene@23b656b843d2a3461cf38e4fd466c07a822d5fc0
+        uses: twilio/sdk-actions/uv-lockfile-hygiene@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
 
   lint:
     name: Linting
@@ -28,7 +28,7 @@ jobs:
 
       - name: Authenticate with Artifactory
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0
+        uses: twilio/sdk-actions/artifactory-oidc@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
         with:
           ecosystem: python
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Authenticate with Artifactory
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0
+        uses: twilio/sdk-actions/artifactory-oidc@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
         with:
           ecosystem: python
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Authenticate with Artifactory
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0
+        uses: twilio/sdk-actions/artifactory-oidc@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
         with:
           ecosystem: python
 
@@ -154,7 +154,7 @@ jobs:
 
       - name: Authenticate with Artifactory
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0
+        uses: twilio/sdk-actions/artifactory-oidc@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
         with:
           ecosystem: python
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Authenticate with Artifactory
-        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0
+        uses: twilio/sdk-actions/artifactory-oidc@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
         with:
           ecosystem: python
       - uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Authenticate with Artifactory
-        uses: twilio/sdk-actions/artifactory-oidc@23b656b843d2a3461cf38e4fd466c07a822d5fc0
+        uses: twilio/sdk-actions/artifactory-oidc@26f95a54e57993c1bf3b26bec2905f395814c23a # v1.0.0
         with:
           ecosystem: python
       - uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5


### PR DESCRIPTION
## Summary

Repins all `twilio/sdk-actions` references (CI + deploy workflows) from the interim `@23b656b8…` SHA to the **v1.0.0 release commit** (`26f95a5`), now that sdk-actions has cut its first release.

Pins follow the SHA + version-comment convention (`uses: …@<sha> # v1.0.0`): the full commit SHA keeps the pin immutable (supply-chain best practice), while the trailing `# v1.0.0` lets Dependabot (already configured for the `github-actions` ecosystem) track and bump the version.

- `ci.yml`: `uv-lockfile-hygiene` + `artifactory-oidc`
- `deploy.yml`: `artifactory-oidc`

## Type of Change

- [x] Refactoring

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)